### PR TITLE
Fix names on donations page

### DIFF
--- a/www.divd.nl/assets/js/supp.js
+++ b/www.divd.nl/assets/js/supp.js
@@ -20,7 +20,7 @@ function update_display(data) {
 		if( d.anonymous ) {
 			txt += "<td>Anonymous</td>"
 		} else { 
-			txt += "<td>"+$("<div>").text(d.name).html()+"</td>"
+			txt += "<td>"+$("<div>").text(d.first_name).html()+" "+$("<div>").text(d.last_name_prefix).html()+" "+$("<div>").text(d.last_name).html()+"</td>"
 		}
 		txt += "<td>"+$("<div>").text(d.message).html()+"</td>"
 		txt += "</tr>"


### PR DESCRIPTION
Right now, names (for everybody not being Anonymous) are not displayed (#128) as the data has no tag called "name". Instead, it has `first_name`, `last_name_prefix`, and `last_name`. This changes uses those parameters to display the donators name. However, my Javascript is somewhat rusty so I don't know what happens when there's no `last_name` present or no `last_name_prefix` so perhaps someone else should also look at this.