### PR TITLE
Add security tile for public documents

### DIFF
--- a/www.divd.nl/_includes/footer.html
+++ b/www.divd.nl/_includes/footer.html
@@ -3,6 +3,7 @@
         <div class="inner">
             <div class="content">
                 <ul class="plain">
+                    <li><a href="/partners"><i class="icon fa-address-book-o">&nbsp;</i>Partners</a></li>
                     <li><a href="https://twitter.com/DIVDnl"><i class="icon fa-twitter">&nbsp;</i>Twitter</a></li>
                     <li><a href="https://github.com/DIVD-NL"><i class="icon fa-github">&nbsp;</i>Github</a></li>
                 </ul>
@@ -18,6 +19,5 @@
     {% for script in page.scripts %}
         <script type="text/javascript" src="/assets/js/{{ script }}"></script>
     {% endfor %}
-    <bla></bla>
 </body>
 </html>

--- a/www.divd.nl/index.md
+++ b/www.divd.nl/index.md
@@ -57,10 +57,10 @@ description: DIVD
     <section>
         <div class="content">
             <header>
-                <a href="/partners" class="icon fa-address-book-o"><span class="label">Icon</span></a>
-                <h3>PARTNERS</h3>
+                <a href="/security" class="icon fa-shield"><span class="label">Icon</span></a>
+                <h3>SECURITY</h3>
             </header>
-            <p>Who we collaborate with, our sponsors and references</p>
+            <p>Public documents and reports about (our) security</p>
         </div>
     </section>
     <section>

--- a/www.divd.nl/security.md
+++ b/www.divd.nl/security.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: security
+header: security
+---
+<header>
+	<h2>security</h2>
+</header>
+This page lists our publicly availably documents focussing on policies and visions.
+
+### Reports
+
+* [Informatiebeveiligings beleid](/uploads/OPENBAAR%20-%20Informatiebeveiligingsbeleid%20v1.0.pdf) (Dutch)
+* [Security Visie DIVD](/uploads/OPENBAAR%20-%20Security%20Visie%20v1.0.pdf) (Dutch)


### PR DESCRIPTION
Introduces a new page for documents around security policies
and visions. Texts are not final but this includes the barebones. This also
moves the "parters" part to the footer to keep the tiles in a nice 3x3 format.

Fixes #122 