### PR TITLE
Remove trailing space from URL

### DIFF
--- a/www.divd.nl/reports/2021-00003 - Facebook Leak.md
+++ b/www.divd.nl/reports/2021-00003 - Facebook Leak.md
@@ -12,7 +12,7 @@ excerpt: This is actually a non-report, but it demonstrates where we draw the bo
 This is actually a non-report, but it demonstrates where we draw the boundaries on what we can and cannot do according to our code of conduct.
 
 On April 4 several news platforms reported personal data of 533 million Facebook users was leaked. Security Researcher Alon Gal reported the dataset was now available for free online.
-<https://www.theverge.com/2021/4/4/22366822/facebook-personal-data-533-million-leaks-online-email-phone-numbers >
+<https://www.theverge.com/2021/4/4/22366822/facebook-personal-data-533-million-leaks-online-email-phone-numbers>
 
 On April 9, DIVD researchers were offered a dataset of 5.3 million Dutch users, containing name, place of residence and mobile phone numbers. The first idea that came up was to send all these users an SMS text message to warn them their data was leaked and be extra careful not to respond to suspicious phone calls. Aside from the legal and logistical problems, we decided not to proceed as the media was catching up on the issue, warning users and redirecting them to Have I been Pwned.
 


### PR DESCRIPTION
Last warning that linkchecker gave was about a trailing space. This should fix that

```
URL        `https://www.theverge.com/2021/4/4/22366822/facebook-personal-data-533-million-leaks-online-email-phone-numbers'
Name       `https://www.theverge.com/2021/4/4/22366822/facebook-personal-data-533-million-leaks-online-email-phone-numbers '
Parent URL https://www.divd.nl/reports/2021-00003%20-%20Facebook%20Leak/, line 63, col 1
Base       https://www.divd.nl/
Real URL   https://www.theverge.com/2021/4/4/22366822/facebook-personal-data-533-million-leaks-online-email-phone-numbers
Check time 2.758 seconds
Size       36.42KB
Warning    [url-whitespace] Leading or trailing whitespace in URL
           `https://www.theverge.com/2021/4/4/22366822/facebook-personal-data-533-million-leaks-online-email-phone-numbers
           '.
Result     Valid: 200 OK
```