### PR TITLE
Update DIVD-2021-00038 - Update of timeline, latest patch version and reference to the DIVD blog article

### DIFF
--- a/csirt.divd.nl/_cases/DIVD-2021-00038.md
+++ b/csirt.divd.nl/_cases/DIVD-2021-00038.md
@@ -44,13 +44,13 @@ We are scanning the internet for vulnerable servers, and will notify system owne
 
 | Date | Description |
 |:-----:|-------------|
-| 09-12-2021 | Lunasec reported about the vulnerability |
+| 09-12-2021 | Lunasec reported about the vulnerability. |
 | 09-12-2021 | Proof of Concept code becomes publicly available. |
 | 10-12-2021 | DIVD starts scanning the internet for CVE-2021-44228. |
-| 12-12-2021 | DIVD sent out a first batch of notifications |
-| 13-12-2021 | DIVD and [DTACT](https://dtact.com/) published a open-source local scanning tool, its on [Github](https://github.com/dtact/divd-2021-00038--log4j-scanner) |
-| 17-12-2021 | DIVD sent out a second batch of notifications |
-| 19-12-2021 | DIVD sent out a third batch of notifications |
+| 12-12-2021 | DIVD sent out a first batch of notifications. |
+| 13-12-2021 | DIVD and [DTACT](https://dtact.com/) published a open-source local scanning tool, its on [Github](https://github.com/dtact/divd-2021-00038--log4j-scanner). |
+| 17-12-2021 | DIVD sent out a second batch of notifications. |
+| 19-12-2021 | DIVD sent out a third batch of notifications. |
 
 ## More information
 * [Lunasec Advisory](https://www.lunasec.io/docs/blog/log4j-zero-day/)

--- a/csirt.divd.nl/_cases/DIVD-2021-00038.md
+++ b/csirt.divd.nl/_cases/DIVD-2021-00038.md
@@ -22,9 +22,9 @@ researchers:
 cves:
 - CVE-2021-44228
 product: Apache log4j
-versions: 2.0 <= Apache and log4j2 <= 2.14.1
+versions: 2.0 <= Apache and log4j2 <= 2.15.0-rc1
 recommendation: "
-Install the latest version of log4j version 2.15.0-rc2 "
+Install the latest version of log4j version 2.17.0"
 patch_status:	 	Full patched
 -workaround:		n/a
 ---
@@ -34,7 +34,7 @@ Apache reported a remote code execution vulnerability in Apache Log4j2, the vuln
 
 ## What you can do
 
-If you run Apache with version less then 2.0 or Apache and/or log4j2 less then 2.14.1 upgrade to version 2.15.0-rc2 as soon as possible.
+If you run Apache with version less then 2.0 or Apache and/or log4j2 less then 2.15.0-rc1 upgrade to version 2.17.0 as soon as possible.
 
 ## What we are doing
 
@@ -47,6 +47,12 @@ We are scanning the internet for vulnerable servers, and will notify system owne
 | 09-12-2021 | Lunasec reported about the vulnerability |
 | 09-12-2021 | Proof of Concept code becomes publicly available. |
 | 10-12-2021 | DIVD starts scanning the internet for CVE-2021-44228. |
+| 12-12-2021 | First notifications sent out |
+| 13-12-2021 | DIVD and [DTACT](https://dtact.com/) published a open-source local scanning tool, its on [Github](https://github.com/dtact/divd-2021-00038--log4j-scanner) |
+| 17-12-2021 | DIVD sent out a second batch of notifications |
+| 19-12-2021 | DIVD sent out a third batch of notifications |
 
 ## More information
 * [Lunasec Advisory](https://www.lunasec.io/docs/blog/log4j-zero-day/)
+* [DIVD article](https://csirt.divd.nl/2021/12/14/Update-Apache-log4j-remote-code-execution/)
+

--- a/csirt.divd.nl/_cases/DIVD-2021-00038.md
+++ b/csirt.divd.nl/_cases/DIVD-2021-00038.md
@@ -47,7 +47,7 @@ We are scanning the internet for vulnerable servers, and will notify system owne
 | 09-12-2021 | Lunasec reported about the vulnerability |
 | 09-12-2021 | Proof of Concept code becomes publicly available. |
 | 10-12-2021 | DIVD starts scanning the internet for CVE-2021-44228. |
-| 12-12-2021 | First notifications sent out |
+| 12-12-2021 | DIVD sent out a first batch of notifications |
 | 13-12-2021 | DIVD and [DTACT](https://dtact.com/) published a open-source local scanning tool, its on [Github](https://github.com/dtact/divd-2021-00038--log4j-scanner) |
 | 17-12-2021 | DIVD sent out a second batch of notifications |
 | 19-12-2021 | DIVD sent out a third batch of notifications |


### PR DESCRIPTION
Added new official patch version due to the potential bypass in 2.15.0-rc1.
Added mail runs + publication of the DIVD/DTACT scanner to the timeline.
Added DIVD blog article to the more information list.
Added dots to the end of each sentence in the timeline.