### PR TITLE
Add CVE, patch status, HP bulletin, latest action

### DIFF
--- a/csirt.divd.nl/_cases/DIVD-2021-00039.md
+++ b/csirt.divd.nl/_cases/DIVD-2021-00039.md
@@ -14,11 +14,11 @@ researchers:
 - Wouter Schoot
 - Patrick Hulshof
 cves:
-- CVE n/a
+- CVE-2017-12542
 product: HP iLO
 versions: iLO4 and earlier versions used on HP servers.
 recommendation: "Update the iLO firmware version to the latest official release from HP"
-patch_status:  n/a
+patch_status: latest patch 2.79
 -workaround: n/a
 start: 2021-12-31
 end:
@@ -38,6 +38,9 @@ timeline:
 - start: 2022-01-07
   end:
   event:  DIVD sent out a first batch of notifications.
+- start: 2022-01-28
+  end:
+  event: DIVD start rescan.
 
 ---
 ## Summary
@@ -69,3 +72,4 @@ We are scanning the internet for vulnerable servers, and will notify system owne
 ## More information
 * [Padvish Threats Database](https://threats.amnpardaz.com/en/2021/12/28/implant-arm-ilobleed-a/)
 * [NCSC Advisories](https://advisories.ncsc.nl/advisory?id=NCSC-2022-0006)
+* [HP Customer Bulliten](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-a00120318en_us)

--- a/csirt.divd.nl/_cases/DIVD-2021-00039.md
+++ b/csirt.divd.nl/_cases/DIVD-2021-00039.md
@@ -72,4 +72,4 @@ We are scanning the internet for vulnerable servers, and will notify system owne
 ## More information
 * [Padvish Threats Database](https://threats.amnpardaz.com/en/2021/12/28/implant-arm-ilobleed-a/)
 * [NCSC Advisories](https://advisories.ncsc.nl/advisory?id=NCSC-2022-0006)
-* [HP Customer Bulliten](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-a00120318en_us)
+* [HP Customer Bulletin](https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-a00120318en_us)


### PR DESCRIPTION
HPE has indicated that the vulnerability with CVE attribute CVE-2017-12452 was exploited to install the rootkit. Added link to the HPE bulletin, and out latest action.