### PR TITLE
CasePlugin needed on www site too

### DIFF
--- a/www.divd.nl/_plugins/casesPlugin.rb
+++ b/www.divd.nl/_plugins/casesPlugin.rb
@@ -1,0 +1,1 @@
+../../csirt.divd.nl/_plugins/casesPlugin.rb


### PR DESCRIPTION
If we don't load the cases plugin on the www site, team pages don't display case numbers